### PR TITLE
fix: correctly calculate the lastPage index

### DIFF
--- a/Source/PagedArray.swift
+++ b/Source/PagedArray.swift
@@ -46,7 +46,11 @@ public struct PagedArray<T> {
     
     /// The last valid page index
     public var lastPage: Int {
-        return count/pageSize+startPage
+        if (count % pageSize) == 0 {
+            return (count/pageSize) - 1
+        } else {
+            return (count/pageSize) + 1
+        }
     }
     
     /// All elements currently set, in order

--- a/Tests/PagedArrayTests.swift
+++ b/Tests/PagedArrayTests.swift
@@ -104,4 +104,38 @@ class PagedArrayTests: XCTestCase {
         XCTAssertEqual(pagedArray.loadedElements.count, 0, "RemoveAllPages should remove all loaded elements")
     }
     
+    func testGetLastPageNumber() {
+        XCTAssertEqual(pagedArray.lastPage, 7)
+    }
+    
+    func testGetLastPageNumberExactCountPageSizeDivision() {
+        var tinyArray: PagedArray<Int> = PagedArray(count: 30, pageSize: 10)
+        XCTAssertEqual(tinyArray.lastPage, 2)
+    }
+    
+    func testGetLastPageNumberExactCountPageSizeDivisionWithStartingPage1() {
+        var tinyArray: PagedArray<Int> = PagedArray(count: 30, pageSize: 10, startPage: 1)
+        XCTAssertEqual(tinyArray.lastPage, 2)
+    }
+    
+    func testGetLastPageNumberExactCountPageSizeDivisionWithStartingPage10() {
+        var tinyArray: PagedArray<Int> = PagedArray(count: 30, pageSize: 10, startPage: 10)
+        XCTAssertEqual(tinyArray.lastPage, 2)
+    }
+    
+    func testGetLastPageNumberNotExactCountPageSizeDivision() {
+        var tinyArray: PagedArray<Int> = PagedArray(count: 100, pageSize: 15)
+        XCTAssertEqual(tinyArray.lastPage, 7)
+    }
+    
+    func testGetLastPageNumberNotExactCountPageSizeDivisionStartingPage1() {
+        var tinyArray: PagedArray<Int> = PagedArray(count: 100, pageSize: 15, startPage: 1)
+        XCTAssertEqual(tinyArray.lastPage, 7)
+    }
+    
+    func testGetLastPageNumberNotExactCountPageSizeDivisionStartingPage5() {
+        var tinyArray: PagedArray<Int> = PagedArray(count: 100, pageSize: 15, startPage: 5)
+        XCTAssertEqual(tinyArray.lastPage, 7)
+    }
+    
 }


### PR DESCRIPTION
While working on adding some features to your code for a project I have, I found this bug. The lastPage method is not calculating right the last page index. Please have a look

+ Added test cases